### PR TITLE
feat: enhance alias resolution with comprehensive improvements

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,137 +1,201 @@
 import path from 'node:path'
 import * as vscode from 'vscode'
-import { findAliasExtensions, getAlias, getRootUrl, getUrl } from './utils'
+import { findAliasExtensionsAsync, getAlias, getConfigPathForFile, getRootUrl, getUrls, invalidateAliasCache } from './utils'
 
 // todo: 支持monorepo
 export function activate(context: vscode.ExtensionContext) {
   const rootUrl = getRootUrl()
   if (!rootUrl)
     return
-  const aliasMapPromise = getAlias()
-  const cacheMap = new Map()
-  aliasMapPromise.then((aliasMap) => {
+
+  // 结果缓存，细化到文档 + 行 + aliasUrl
+  const cacheMap = new Map<string, { columnStart: number, columnEnd: number, result: vscode.LocationLink[] } | undefined>()
+
+  const cacheKeyOf = (document: vscode.TextDocument, aliasUrl: string, line: number) => `${document.uri.toString()}|${line}|${aliasUrl}`
+
+  async function loadAliasForDocument(document: vscode.TextDocument, withRetry = false) {
+    const configPath = await getConfigPathForFile(document.uri.fsPath)
+    if (!configPath)
+      return {}
+    if (!withRetry)
+      return (await getAlias(configPath)) || {}
+    const max = 3
+    let delay = 200
+    for (let i = 0; i < max; i++) {
+      const map = await getAlias(configPath)
+      if (map)
+        return map
+      await new Promise(r => setTimeout(r, delay))
+      delay *= 2
+    }
+    return {}
+  }
+
+  function stripQueryHash(u: string) {
+    const q = u.indexOf('?')
+    const h = u.indexOf('#')
+    const cut = [q, h].filter(x => x >= 0)
+    if (!cut.length)
+      return u
+    const i = Math.min(...cut)
+    return u.slice(0, i)
+  }
+
+  async function resolveAbsolute(document: vscode.TextDocument, aliasUrl: string, currentAliasMap: Record<string, string | string[]>): Promise<string> {
+    aliasUrl = stripQueryHash(aliasUrl)
+    const alias = aliasUrl.split('/')[0]
+    let absolutePath = ''
+
+    if (alias[0] === '.') {
+      // 如果最后一段包含扩展名则跳过
+      if (aliasUrl.split('/').slice(-1)[0].includes('.'))
+        return ''
+      absolutePath = await findAliasExtensionsAsync(path.resolve(path.dirname(document.uri.fsPath), aliasUrl))
+    }
+    else {
+      const aliasName = currentAliasMap[alias]
+      if (!aliasName)
+        return ''
+      const bases = Array.isArray(aliasName) ? aliasName : [aliasName]
+      for (const base of bases) {
+        const abs = await findAliasExtensionsAsync(aliasUrl.replace(alias, path.resolve(rootUrl!, base)))
+        if (abs) {
+          absolutePath = abs
+          break
+        }
+      }
+    }
+    return absolutePath
+  }
+
   // 添加 DocumentLinkProvider 来修正 Cmd+Click 跳转
-    const linkProvider = vscode.languages.registerDocumentLinkProvider([
-      { scheme: 'file', language: 'vue' },
-      { scheme: 'file', language: 'scss' },
-      { scheme: 'file', language: 'css' },
-      { scheme: 'file', language: 'less' },
-      { scheme: 'file', language: 'javascript' },
-      { scheme: 'file', language: 'typescript' },
-      { scheme: 'file', language: 'javascriptreact' },
-    ], {
-      provideDocumentLinks(document) {
-        const links: vscode.DocumentLink[] = []
-        const text = document.getText()
-        const lines = text.split('\n')
+  const linkProvider = vscode.languages.registerDocumentLinkProvider([
+    { scheme: 'file', language: 'vue' },
+    { scheme: 'file', language: 'scss' },
+    { scheme: 'file', language: 'css' },
+    { scheme: 'file', language: 'less' },
+    { scheme: 'file', language: 'javascript' },
+    { scheme: 'file', language: 'typescript' },
+    { scheme: 'file', language: 'javascriptreact' },
+    { scheme: 'file', language: 'typescriptreact' },
+  ], {
+    async provideDocumentLinks(document) {
+      const currentAliasMap = await loadAliasForDocument(document, false)
+      const links: vscode.DocumentLink[] = []
+      const text = document.getText()
+      const lines = text.split('\n')
 
-        lines.forEach((lineText, lineIndex) => {
-          const aliasUrl = getUrl(lineText)
-          if (!aliasUrl)
-            return
-
-          const alias = aliasUrl.split('/')[0]
-          let absolutePath = ''
-
-          if (alias[0] === '.') {
-            if (aliasUrl.split('/').slice(-1)[0].includes('.'))
-              return
-            absolutePath = findAliasExtensions(path.resolve(document.uri.fsPath, '../', aliasUrl))
-          }
-          else {
-            const aliasName = aliasMap[alias]
-            if (!aliasName)
-              return
-            absolutePath = findAliasExtensions(aliasUrl.replace(alias, path.resolve(rootUrl, aliasName)))
-          }
-
+      for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+        const lineText = lines[lineIndex]
+        const found = getUrls(lineText)
+        if (!found.length)
+          continue
+        for (const f of found) {
+          const absolutePath = await resolveAbsolute(document, f.url, currentAliasMap)
           if (!absolutePath)
-            return
-
-          const startIndex = lineText.indexOf(aliasUrl)
-          if (startIndex === -1)
-            return
-
+            continue
           const range = new vscode.Range(
             lineIndex,
-            startIndex,
+            f.start,
             lineIndex,
-            startIndex + aliasUrl.length,
+            f.end,
           )
+          links.push(new vscode.DocumentLink(range, vscode.Uri.file(absolutePath)))
+        }
+      }
 
-          const link = new vscode.DocumentLink(range, vscode.Uri.file(absolutePath))
-          links.push(link)
-        })
+      return links
+    },
+  })
 
-        return links
-      },
-    })
+  const hoverHander = vscode.languages.registerDefinitionProvider([
+    { scheme: 'file', language: 'vue' },
+    { scheme: 'file', language: 'scss' },
+    { scheme: 'file', language: 'css' },
+    { scheme: 'file', language: 'less' },
+    { scheme: 'file', language: 'javascript' },
+    { scheme: 'file', language: 'typescript' },
+    { scheme: 'file', language: 'javascriptreact' },
+    { scheme: 'file', language: 'typescriptreact' },
+  ], {
+    async provideDefinition(document, position) {
+      const linetext = document.lineAt(position).text // 当前行字符串
+      const foundInLine = getUrls(linetext)
+      if (!foundInLine.length)
+        return
+      // 定位光标所在的 url 片段
+      const current = foundInLine.find(f => position.character >= f.start && position.character <= f.end)
+      if (!current)
+        return
+      const aliasUrl = current.url
 
-    const hoverHander = vscode.languages.registerDefinitionProvider([
-      { scheme: 'file', language: 'vue' },
-      { scheme: 'file', language: 'scss' },
-      { scheme: 'file', language: 'css' },
-      { scheme: 'file', language: 'less' },
-      { scheme: 'file', language: 'javascript' },
-      { scheme: 'file', language: 'typescript' },
-      { scheme: 'file', language: 'javascriptreact' },
-    ], {
-      provideDefinition(document, position) {
-        const linetext = document.lineAt(position).text // 当前行字符串
-        const aliasUrl = getUrl(linetext)
-        if (!aliasUrl)
+      const currentAliasMap = await loadAliasForDocument(document, false)
+
+      const key = cacheKeyOf(document, aliasUrl, position.line)
+      if (cacheMap.has(key)) {
+        const cache = cacheMap.get(key)
+        if (!cache)
           return
-        if (cacheMap.has(aliasUrl)) {
-          const cache = cacheMap.get(aliasUrl)
-          if (!cache)
-            return
-          const { columnStart, columnEnd, result } = cache
-          if ((position.character < columnStart) || (position.character > columnEnd))
-            return
-
-          return result
-        }
-        const alias = aliasUrl.split('/')[0]
-        let absolutePath = ''
-        if (alias[0] === '.') {
-          if (aliasUrl.split('/').slice(-1)[0].includes('.'))
-            return
-          absolutePath = findAliasExtensions(path.resolve(document.uri.fsPath, '../', aliasUrl))
-        }
-        else {
-          const aliasName = aliasMap[alias]
-          if (!aliasName)
-            return
-
-          absolutePath = findAliasExtensions(aliasUrl.replace(alias, path.resolve(rootUrl, aliasName)))
-        }
-
-        if (!absolutePath) {
-          cacheMap.set(aliasUrl, undefined)
-          return
-        }
-
-        const columnStart = linetext.indexOf(aliasUrl)
-        const columnEnd = columnStart + aliasUrl.length
-
-        const originSelectionRange = new vscode.Range(position.line, columnStart - 1, position.line, columnEnd + 1)
-        const result = [
-          {
-            originSelectionRange,
-            targetRange: new vscode.Range(0, 0, 0, 0),
-            targetUri: vscode.Uri.file(absolutePath),
-          },
-        ]
-        cacheMap.set(aliasUrl, { columnStart, columnEnd, result })
+        const { columnStart, columnEnd, result } = cache
         if ((position.character < columnStart) || (position.character > columnEnd))
           return
 
         return result
-      },
-    })
+      }
 
-    context.subscriptions.push(linkProvider, hoverHander)
+      const absolutePath = await resolveAbsolute(document, aliasUrl, currentAliasMap)
+      if (!absolutePath) {
+        cacheMap.set(key, undefined)
+        return
+      }
+
+      const columnStart = current.start
+      const columnEnd = current.end
+
+      const originSelectionRange = new vscode.Range(position.line, columnStart - 1, position.line, columnEnd + 1)
+      const result = [
+        {
+          originSelectionRange,
+          targetRange: new vscode.Range(0, 0, 0, 0),
+          targetUri: vscode.Uri.file(absolutePath),
+        },
+      ] as vscode.LocationLink[]
+      cacheMap.set(key, { columnStart, columnEnd, result })
+      if ((position.character < columnStart) || (position.character > columnEnd))
+        return
+
+      return result
+    },
   })
+
+  // 监听 tsconfig/jsconfig 变更，重载别名与清理缓存
+  const configWatcher = vscode.workspace.createFileSystemWatcher('**/{tsconfig.json,jsconfig.json}')
+  const onConfigChanged = () => {
+    cacheMap.clear()
+    invalidateAliasCache()
+  }
+  configWatcher.onDidChange(onConfigChanged, undefined, context.subscriptions)
+  configWatcher.onDidCreate(onConfigChanged, undefined, context.subscriptions)
+  configWatcher.onDidDelete(onConfigChanged, undefined, context.subscriptions)
+
+  // 文档变更/关闭时，清理该文档的缓存
+  const clearDocCache = (uri: vscode.Uri) => {
+    const prefix = `${uri.toString()}|`
+    for (const k of Array.from(cacheMap.keys())) {
+      if (k.startsWith(prefix))
+        cacheMap.delete(k)
+    }
+  }
+
+  context.subscriptions.push(
+    linkProvider,
+    hoverHander,
+    configWatcher,
+    vscode.workspace.onDidChangeTextDocument(e => clearDocCache(e.document.uri)),
+    vscode.workspace.onDidCloseTextDocument(doc => clearDocCache(doc.uri)),
+  )
+
+  // 初次无需预加载别名，按需加载
 }
 
 export function deactivate() {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,12 +6,41 @@ import { isArray, toArray, useJSONParse } from 'lazy-js-utils'
 import * as vscode from 'vscode'
 
 export function getUrl(str: string) {
-  const importUrl = /import[\s\w,{}]+from[^('"]+['"]([^'"]+)['"]/
-  const imporCsstUrl = /import\s+['"]([^'"]+)['"]/
-  // const requireUrl = /require\(['"]([^'"]+)['"]\)/
-  // const srcUrl = /src="([^"]+)"/
-  const match = str.match(imporCsstUrl) || str.match(importUrl)
-  return match ? match[1] : ''
+  const first = getUrls(str)[0]
+  return first ? first.url : ''
+}
+
+export interface FoundUrl {
+  url: string
+  start: number
+  end: number
+}
+
+// 提取一行内的所有 URL（import/from、纯样式 import、动态 import、require、HTML src）
+export function getUrls(str: string): FoundUrl[] {
+  const patterns: RegExp[] = [
+    /import\s+['"]([^'"]+)['"]/g, // import '...'
+    /import[\s\w,{}]+from[^('")]+['"]([^'"]+)['"]/g, // import x from '...'
+    /import\(\s*['"]([^'"]+)['"]\s*\)/g, // import('...')
+    /require\(\s*['"]([^'"]+)['"]\s*\)/g, // require('...')
+    /src\s*=\s*['"]([^'"]+)['"]/g, // src="..."
+    /url\(\s*['"]?([^'")]+)['"]?\s*\)/g, // url("...") in CSS
+  ]
+
+  const results: FoundUrl[] = []
+  for (const re of patterns) {
+    let m: RegExpExecArray | null
+    while ((m = re.exec(str)) !== null) {
+      const full = m[0]
+      const captured = m[1]
+      const start = (m.index ?? 0) + full.indexOf(captured)
+      const end = start + captured.length
+      results.push({ url: captured, start, end })
+    }
+  }
+  // 保持按出现顺序排序
+  results.sort((a, b) => a.start - b.start)
+  return results
 }
 
 export function getRootUrl() {
@@ -20,9 +49,9 @@ export function getRootUrl() {
     return workspaceFolders[0].uri.fsPath
 }
 
-const workspaceMap = new Map()
-async function getCurrentWorkspaceUrl() {
-  const currentFileUrl = getCurrentFileUrl()!
+const workspaceMap = new Map<string, string | undefined>()
+export async function getCurrentWorkspaceUrl(filePath?: string) {
+  const currentFileUrl = filePath || getCurrentFileUrl()!
   if (!currentFileUrl)
     return
 
@@ -42,8 +71,31 @@ async function getCurrentWorkspaceUrl() {
   workspaceMap.set(currentFileUrl, undefined)
 }
 
+// 根据文件路径解析对应 ts/jsconfig 的绝对路径
+export async function getConfigPathForFile(filePath: string) {
+  const ws = await getCurrentWorkspaceUrl(filePath)
+  if (!ws)
+    return
+  let configPath = resolve(ws, 'tsconfig.json')
+  if (!existsSync(configPath))
+    configPath = resolve(ws, 'jsconfig.json')
+  if (!existsSync(configPath))
+    return
+  return configPath
+}
+
 // 获取当前package.json下的配置
 const aliasMap = new Map()
+
+// 允许外部主动清理别名与工作区缓存（配置文件变化时调用）
+export function invalidateAliasCache(configPath?: string) {
+  if (configPath)
+    aliasMap.delete(configPath)
+  else
+    aliasMap.clear()
+  workspaceMap.clear()
+}
+
 export async function getAlias(configUrl?: string, visited = new Set<string>()) {
   let configPath = configUrl
   if (!configPath) {
@@ -64,37 +116,68 @@ export async function getAlias(configUrl?: string, visited = new Set<string>()) 
   const cacheKey = configPath
   if (aliasMap.has(cacheKey))
     return aliasMap.get(cacheKey)
+  // 标记占位，避免并发重复读取
   aliasMap.set(cacheKey, undefined)
 
-  const _config = useJSONParse(await promises.readFile(configPath, 'utf-8'))
-  if (!_config)
+  // 安全读取配置
+  let fileText = ''
+  try {
+    fileText = await promises.readFile(configPath, 'utf-8')
+  }
+  catch {
+    aliasMap.delete(cacheKey)
     return
+  }
+  const _config = useJSONParse(fileText)
+  if (!_config) {
+    aliasMap.delete(cacheKey)
+    return
+  }
 
-  const result: Record<string, string> = {}
+  const result: Record<string, string | string[]> = {}
 
   // 递归处理 references
   if (_config.references && Array.isArray(_config.references)) {
     const refPromises = _config.references
       .filter((ref: any) => ref.path)
       .map((ref: any) => {
-        const refConfigPath = resolve(path.dirname(configPath), ref.path)
-        if (existsSync(refConfigPath)) {
-          return getAlias(refConfigPath, visited)
+        let refConfigPath = resolve(path.dirname(configPath!), ref.path)
+        try {
+          const stat = fs.statSync(refConfigPath)
+          if (stat.isDirectory()) {
+            const tsconfig = resolve(refConfigPath, 'tsconfig.json')
+            const jsconfig = resolve(refConfigPath, 'jsconfig.json')
+            if (existsSync(tsconfig))
+              refConfigPath = tsconfig
+            else if (existsSync(jsconfig))
+              refConfigPath = jsconfig
+            else
+              return Promise.resolve({})
+          }
         }
+        catch {
+          // 既不是文件也不是目录，或不存在
+          return Promise.resolve({})
+        }
+        if (existsSync(refConfigPath))
+          return getAlias(refConfigPath, visited)
         return Promise.resolve({})
       })
     const refAliases = await Promise.all(refPromises)
     for (const refAlias of refAliases) {
       for (const key in refAlias) {
-        if (result[key] && result[key] !== refAlias[key]) {
-          // 已有同名 alias，合并为数组，去重
-          const arr = toArray(result[key])
-          if (!arr.includes(refAlias[key]))
-            arr.push(refAlias[key])
+        const prev = result[key]
+        const incoming = refAlias[key] as any
+        if (prev && prev !== incoming) {
+          const arr = toArray(prev)
+          for (const v of toArray(incoming)) {
+            if (!arr.includes(v))
+              arr.push(v)
+          }
           result[key] = arr as any
         }
         else {
-          result[key] = refAlias[key]
+          result[key] = incoming
         }
       }
     }
@@ -103,24 +186,26 @@ export async function getAlias(configUrl?: string, visited = new Set<string>()) 
   const paths = _config?.compilerOptions?.paths
   if (paths) {
     Object.keys(paths).forEach((key: any) => {
-      let value = paths[key]
-      if (isArray(value))
-        value = value[0]
+      const value = paths[key]
+      // 支持多候选路径，先以第一个为主，后续按顺序合并
+      const values = isArray(value) ? value : [value]
       key = key.replace(/\/\*\*/g, '').replace(/\/\*/g, '')
-      value = value.replace(/\/\*\*/g, '').replace(/\/\*/g, '')
+      const normalizedValues = values.map((v: string) => v.replace(/\/\*\*/g, '').replace(/\/\*/g, ''))
       if (key === '@') {
         key = '@/'
-        value = `${value}/`
+        normalizedValues[0] = `${normalizedValues[0]}/`
       }
-      if (result[key] && result[key] !== value) {
-        // 已有同名 alias，合并为数组，去重
-        const arr = toArray(result[key])
-        if (!arr.includes(value))
-          arr.push(value)
-        result[key] = arr as any
-      }
-      else {
-        result[key] = value
+      for (const nv of normalizedValues) {
+        if (result[key] && result[key] !== nv) {
+          // 已有同名 alias，合并为数组，去重
+          const arr = toArray(result[key])
+          if (!arr.includes(nv))
+            arr.push(nv)
+          result[key] = arr as any
+        }
+        else {
+          result[key] = nv
+        }
       }
     })
   }
@@ -150,6 +235,33 @@ export function findAliasExtensions(url: string) {
 function isFile(url: string) {
   try {
     const stats = fs.statSync(url)
+    return stats.isFile()
+  }
+  catch (error) {
+    return false
+  }
+}
+
+export async function findAliasExtensionsAsync(url: string) {
+  if (await isFileAsync(url))
+    return url
+
+  for (const suffix of ['.js', '.ts', '.jsx', '.tsx', '.vue']) {
+    const extensionUrl = `${url}${suffix}`
+    if (await isFileAsync(extensionUrl))
+      return extensionUrl
+  }
+  for (const suffix of extensions) {
+    const extensionUrl = `${url}/index${suffix}`
+    if (await isFileAsync(extensionUrl))
+      return extensionUrl
+  }
+  return ''
+}
+
+async function isFileAsync(url: string) {
+  try {
+    const stats = await promises.stat(url)
     return stats.isFile()
   }
   catch (error) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,7 @@
     "esModuleInterop": true,
     "skipDefaultLibCheck": true,
     "skipLibCheck": true
-  }
+  },
+  "include": ["src", "test"],
+  "exclude": ["tsup.config.ts"]
 }


### PR DESCRIPTION
- Add retry mechanism for alias loading with exponential backoff
- Watch tsconfig/jsconfig changes and auto-refresh alias maps
- Support per-document alias resolution for monorepo scenarios
- Add multi-URL extraction per line (import/require/dynamic import/src/CSS url)
- Support multi-candidate alias paths with priority order
- Refine cache key to document+line+aliasUrl to avoid conflicts
- Clear document cache on text change/close events
- Add async file resolution to avoid blocking event loop
- Strip query/hash from URLs before resolution
- Support TypeScript React language
- Export invalidateAliasCache, getConfigPathForFile, getCurrentWorkspaceUrl
- Handle tsconfig references as directory paths
- Improve relative path resolution using path.dirname
- Update tsconfig.json to exclude build config from typecheck